### PR TITLE
Add the cmd flag to the Run and Create commands

### DIFF
--- a/crane/cmd.go
+++ b/crane/cmd.go
@@ -22,6 +22,7 @@ type Options struct {
 	cascadeAffected     string
 	config              string
 	target              []string
+	cmd                 string
 }
 
 var options Options
@@ -84,7 +85,7 @@ If no Dockerfile is given, it will pull the image(s) from the given registry.`,
 		Short: "Create the containers",
 		Long:  `run will call docker create for all targeted containers.`,
 		Run: configCommand(func(config Config) {
-			config.TargetedContainers().create(options.recreate)
+			config.TargetedContainers().create(options.recreate, options.cmd)
 		}, false),
 	}
 
@@ -93,7 +94,7 @@ If no Dockerfile is given, it will pull the image(s) from the given registry.`,
 		Short: "Run the containers",
 		Long:  `run will call docker run for all targeted containers.`,
 		Run: configCommand(func(config Config) {
-			config.TargetedContainers().run(options.recreate)
+			config.TargetedContainers().run(options.recreate, options.cmd)
 		}, false),
 	}
 
@@ -240,8 +241,10 @@ See the corresponding docker commands for more information.`,
 	cmdProvision.Flags().BoolVarP(&options.nocache, "no-cache", "n", false, "Build the image without any cache")
 
 	cmdCreate.Flags().BoolVarP(&options.recreate, "recreate", "r", false, "Recreate containers (force-remove containers first)")
+	cmdCreate.Flags().StringVarP(&options.cmd, "cmd", "", "", "Overwrites defined command")
 
 	cmdRun.Flags().BoolVarP(&options.recreate, "recreate", "r", false, "Recreate containers (force-remove containers first)")
+	cmdRun.Flags().StringVarP(&options.cmd, "cmd", "", "", "Overwrites defined command")
 
 	cmdRm.Flags().BoolVarP(&options.forceRm, "force", "f", false, "Kill containers if they are running first")
 

--- a/crane/container.go
+++ b/crane/container.go
@@ -24,8 +24,8 @@ type Container interface {
 	Status() []string
 	Provision(nocache bool)
 	ProvisionOrSkip(update bool, nocache bool)
-	Create()
-	Run()
+	Create(cmd string)
+	Run(cmd string)
 	Start()
 	RunOrStart()
 	Kill()
@@ -393,7 +393,7 @@ func (c *container) RunOrStart() {
 	if c.Exists() {
 		c.Start()
 	} else {
-		c.Run()
+		c.Run("")
 	}
 }
 
@@ -405,10 +405,14 @@ func (c *container) ProvisionOrSkip(update bool, nocache bool) {
 }
 
 // Create container
-func (c *container) Create() {
+func (c *container) Create(cmd string) {
 	if c.Exists() {
 		print.Noticef("Container %s does already exist. Use --recreate to recreate.\n", c.Name())
 	} else {
+		if cmd != "" {
+			c.RunParams.RawCmd = cmd
+		}
+
 		fmt.Printf("Creating container %s ... ", c.Name())
 		args := append([]string{"create"}, c.createArgs()...)
 		executeCommand("docker", args)
@@ -416,13 +420,17 @@ func (c *container) Create() {
 }
 
 // Run container, or start it if already existing
-func (c *container) Run() {
+func (c *container) Run(cmd string) {
 	if c.Exists() {
 		print.Noticef("Container %s does already exist. Use --recreate to recreate.\n", c.Name())
 		if !c.Running() {
 			c.Start()
 		}
 	} else {
+		if cmd != "" {
+			c.RunParams.RawCmd = cmd
+		}
+
 		fmt.Printf("Running container %s ... ", c.Name())
 		args := []string{"run"}
 		// Detach

--- a/crane/containers.go
+++ b/crane/containers.go
@@ -47,23 +47,24 @@ func (containers Containers) provision(nocache bool) {
 
 // Create containers.
 // When recreate is true, removes existing containers first.
-func (containers Containers) create(recreate bool) {
+func (containers Containers) create(recreate bool, cmd string) {
 	if recreate {
 		containers.rm(true)
 	}
 	for _, container := range containers {
-		container.Create()
+		container.Create(cmd)
 	}
 }
 
 // Run containers.
 // When recreate is true, removes existing containers first.
-func (containers Containers) run(recreate bool) {
+func (containers Containers) run(recreate bool, cmd string) {
 	if recreate {
 		containers.rm(true)
 	}
+
 	for _, container := range containers {
-		container.Run()
+		container.Run(cmd)
 	}
 }
 


### PR DESCRIPTION
Cmd flag will overwrite the command defined on the Crane configuration
Example:

```
containers:
  test:
    image: busybox
    run:
      cmd: ["echo", "foo"]
      rm: true
```

```
$ crane run test
Running container test ... foo
$ crane run test --cmd="echo bar"
Running container test ... bar
```
